### PR TITLE
Make a separate wrapper around colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ lit and unlit pixels sufficiently. In that case, this repository also includes t
 
 ## Next steps
 
-- [ ] Convert true colors to palette colors
+- [x] Convert true colors to palette colors
 - [ ] Operations to read sprites from image files in more advanced ways
 - [ ] A simple rendering loop
 - [ ] Read input

--- a/examples/smiley.rs
+++ b/examples/smiley.rs
@@ -1,7 +1,7 @@
 use std::{io, time::Duration};
 
 use ti::{
-    color::Color,
+    color::standard,
     screen::{Blit, Screen},
     sprite::Sprite,
 };
@@ -25,8 +25,6 @@ fn main() -> io::Result<()> {
 }
 
 fn draw_smiley(screen: &mut Screen, x: u16, y: u16, blit: Blit) {
-    let smiley =
-        Sprite::from_braille_string(&["⢌⣈⠄"], Some(Color::from_rgb_approximate(0, 255, 0)))
-            .unwrap();
+    let smiley = Sprite::from_braille_string(&["⢌⣈⠄"], Some(standard::GREEN)).unwrap();
     screen.draw_sprite(&smiley, x, y, blit);
 }

--- a/examples/smiley.rs
+++ b/examples/smiley.rs
@@ -25,6 +25,8 @@ fn main() -> io::Result<()> {
 }
 
 fn draw_smiley(screen: &mut Screen, x: u16, y: u16, blit: Blit) {
-    let smiley = Sprite::from_braille_string(&["⢌⣈⠄"], Some(Color::Green)).unwrap();
+    let smiley =
+        Sprite::from_braille_string(&["⢌⣈⠄"], Some(Color::from_rgb_approximate(0, 255, 0)))
+            .unwrap();
     screen.draw_sprite(&smiley, x, y, blit);
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -303,4 +303,11 @@ mod tests {
             Color::from_ansi_greyscale(23)
         );
     }
+    #[test]
+    fn test_greyscale_incrementing() {
+        let colors: Vec<_> = (0..24).map(Color::from_ansi_greyscale).collect();
+        let mut sorted = colors.clone();
+        sorted.sort_by(|a, b| a.to_rgb_approximate().0.cmp(&b.to_rgb_approximate().0));
+        assert_eq!(colors, sorted)
+    }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -64,9 +64,44 @@ fn dist(a: (u8, u8, u8), b: (u8, u8, u8)) -> f32 {
     .cbrt()
 }
 
+macro_rules! define_standard_colors {
+    ($($name:ident $str:literal $num:literal),+) => {
+        $(
+            #[doc = "The ANSI standard"]
+            #[doc = $str]
+            #[doc = "color. Its appearance varies across terminals and themes."]
+            pub const $name: Color = Color::new($num);
+        )+
+    };
+}
+
+/// This module contains the 16 ANSI standard colors, supported by almost all terminals. If you want your program to be
+/// maximally visible on all terminals, and don't mind the colors looking slightly different, you can use these.
+pub mod standard {
+    use super::Color;
+    define_standard_colors! {
+        BLACK "black" 0,
+        RED "red" 1,
+        GREEN "green" 2,
+        YELLOW "yellow" 3,
+        BLUE "blue" 4,
+        MAGENTA "magenta" 5,
+        CYAN "cyan" 6,
+        WHITE "white" 7,
+        BRIGHT_BLACK "bright black" 8,
+        BRIGHT_RED "bright red" 9,
+        BRIGHT_GREEN "bright green" 10,
+        BRIGHT_YELLOW "bright yellow" 11,
+        BRIGHT_BLUE "bright blue" 12,
+        BRIGHT_MAGENTA "bright magenta" 13,
+        BRIGHT_CYAN "bright cyan" 14,
+        BRIGHT_WHITE "bright white" 15
+    }
+}
+
 impl Color {
     /// Creates a new color from an 8-bit ANSI color value.
-    pub fn new(color: u8) -> Self {
+    pub const fn new(color: u8) -> Self {
         Self(color)
     }
     /// Returns an ANSI color that is visually similar to the specified
@@ -125,7 +160,25 @@ impl Color {
     /// ANSI colors (color values from 0 to 15) are often altered by custom themes.
     pub fn to_rgb_approximate(self) -> (u8, u8, u8) {
         match self.0 {
-            0..=15 => todo!("Standard colors not supported yet"),
+            // The standard colors are simple approximations, because every terminal does it differently.
+            // This is a particularly simple choice of colors, following the windows XP console.
+            0 => (0, 0, 0),
+            1 => (128, 0, 0),
+            2 => (0, 128, 0),
+            3 => (128, 128, 0),
+            4 => (0, 0, 128),
+            5 => (128, 0, 128),
+            6 => (0, 128, 128),
+            7 => (192, 192, 192),
+            8 => (128, 128, 128),
+            9 => (255, 0, 0),
+            10 => (0, 255, 0),
+            11 => (255, 255, 0),
+            12 => (0, 0, 255),
+            13 => (255, 0, 255),
+            14 => (0, 255, 255),
+            15 => (255, 255, 255),
+            // 3-component (RGB) colors
             16..=231 => {
                 let offset = self.0 - 16;
                 let r = (offset / 36) % 6;
@@ -133,6 +186,7 @@ impl Color {
                 let b = offset % 6;
                 (RGB[r as usize], RGB[g as usize], RGB[b as usize])
             }
+            // Greyscale colors
             232..=255 => {
                 let step = self.0 - 232;
                 (

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -247,7 +247,7 @@ impl Screen {
     /// use ti::color::Color;
     ///
     /// let mut screen = Screen::new_cells(2, 1);
-    /// let color = Color::AnsiValue(23);
+    /// let color = Color::new(23);
     /// assert!(screen.draw_cell_color(color, 1, 0));
     /// assert_eq!(screen.get_color(1, 0), Some(color));
     /// ```
@@ -321,7 +321,7 @@ impl Screen {
     /// use ti::color::Color;
     ///
     /// let mut screen = Screen::new_cells(2, 2);
-    /// let color = Color::AnsiValue(123);
+    /// let color = Color::new(123);
     /// assert_eq!(screen.get_color(999, 999), None);
     /// screen.draw_cell_color(color, 0, 0);
     /// assert_eq!(screen.get_color(0, 0), Some(color));
@@ -461,7 +461,7 @@ impl Screen {
                 }
                 if color != cur_color {
                     if let Some(color) = color {
-                        buf.queue(SetForegroundColor(color))?;
+                        buf.queue(SetForegroundColor(color.to_crossterm_color()))?;
                     }
                     cur_color = color;
                 }

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -165,7 +165,8 @@ impl Sprite {
 
     /// Parses a sprite from dynamic image data.
     ///
-    /// The `rescale_filter` declares the method used to resize the
+    /// The `rescale_filter` declares the method used to resize to a specified resolution, and `downscale_filter` declares
+    /// the method used to thumbnail each cell into a single color.
     #[cfg(feature = "images")]
     fn from_image_data_rgb_resize(
         img: DynamicImage,
@@ -184,7 +185,8 @@ impl Sprite {
 
         for (x, y, Rgba([r, g, b, _])) in colors.pixels() {
             let index = index(x as u16, y as u16, width_cells);
-            data[index] = ColoredCell::new(Cell::new(0xff), Some(Color::Rgb { r, g, b }));
+            data[index] =
+                ColoredCell::new(Cell::new(0xff), Some(Color::from_rgb_approximate(r, g, b)));
         }
 
         Sprite::new(data, width_cells, height_cells)


### PR DESCRIPTION
Instead of exposing `color::Color` as `crossterm::Color`, make a new struct that wraps an ANSI color (8-bit). 

The use of a palette like this makes the color space technically less expressive than using RGB, but fits the retro aesthetic more, and it's better supported by terminals.

To do:
* [x] Use this in the image parsing methods
* [x] Expose some convenience methods for standard palette colors
* [x] More tests